### PR TITLE
Streamline code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,19 @@ repository = "https://github.com/Sakura1943/shindanmaker-rs"
 documentation = "https://docs.rs/shindanmaker-rs/latest/shindanmaker"
 readme = "README.md"
 
-[dependencies]
-anyhow = "1.0.64"
-reqwest = { version = "0.11.11", features = ["json", "cookies"] }
-scraper = "0.13.0"
-serde = { version = "1.0.144", features = ["derive"], optional = true }
-thiserror = "1.0.34"
-
 [lib]
 name = "shindanmaker"
 
+[dependencies]
+reqwest = { version = "0.11.11", features = ["json", "cookies"] }
+scraper = "0.13.0"
+serde = { version = "1.0.144", features = ["derive"], optional = true }
+
 [features]
-default = []
 serde = ["dep:serde"]
+
+[dev-dependencies]
+tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }
+
+[[example]]
+name = "cli"

--- a/README.md
+++ b/README.md
@@ -1,38 +1,34 @@
-# Shindanmaker in Rust
-A library to visit [https://en.shindanmaker.com/917962](https://en.shindanmaker.com/917962), and use method `get` to achieve data.
+# Shindanmaker Client
+
+A library to visit https://en.shindanmaker.com/917962 .
 
 ## 📔 Usage
-Make sure you activated the shindanmaker-rs crate on Cargo.toml
+
+Add dependencies to `Cargo.toml`:
+
 ```toml
-tokio = { version = "1.21.0", features = ["full"] }
+tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }
 shindanmaker-rs = { version = "0.2.4" }
 ```
-or serde support
-```toml
-tokio = { version = "1.21.0", features = ["full"] }
-shindanmaker-rs = { version = "0.2.4", features = ["serde"] }
-```
-Then, on your main.rs:
-```rust
-use shindanmaker::get;
 
-#[tokio::main]
-async fn main() {
-  let result = get("demo").await.unrwap();
-  println!("{}", result);
-}
-```
-or
-```rust
-use shindanmaker::get;
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-  let result = get("demo").await?;
-  println!("{}", result);
-  Ok(())
-}
+
+## 🤖 Example CLI
+
+Use the following command to fetch and print diagnosis information:
+
+```bash
+$ cargo run --example cli <name>
 ```
 
-## 📔 license
+
+
+## 🛠  Features
+
+- `serde`: *Serialize* and *Deserialize* support for `Card`.
+
+
+
+## 💳 License
+
 MIT license ([LICENSE](./LICENSE) or https://opensource.org/licenses/MIT)

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,0 +1,10 @@
+use shindanmaker::get;
+use std::env::args;
+
+#[tokio::main]
+async fn main() {
+    let name = args().nth(1).unwrap();
+    let card = get(&name).await.unwrap();
+
+    println!("{card}");
+}

--- a/src/card.rs
+++ b/src/card.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
 
+use std::fmt::{self, Display, Formatter};
+
+/// The diagnosis information from `https://en.shindanmaker.com/917962` .
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct Card {
@@ -19,7 +21,7 @@ pub struct Card {
 }
 
 impl Display for Card {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let Self {
             name,
             sex,
@@ -33,6 +35,7 @@ impl Display for Card {
             danger,
             lucky,
         } = self;
+
         write!(
             f,
             "{name}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,0 @@
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("Getting element text failed")]
-    GetElementTextErr,
-}


### PR DESCRIPTION
- gitignore;
- For the convenience of error handling, crate::get only throw `reqwest::Error` in the wrong context;
- The client always hold the user-agent and content-type headers;
- Don't fear `unwrap()`;
- Providing examples to use the crate. Writing too many duplicated snippets is messy.